### PR TITLE
Add note about correct gateway format

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,18 @@ Tutorial: https://vimeo.com/638878051
 Web3 Provider: https://www.alchemy.com/ (Recommended)
 
 Basic IPFS Endpoints: https://ipfs.github.io/public-gateway-checker/
-
+<details>
+  <summary>Note</summary>
+  
+  When you click one the gateways, you might be redirected to a long URL. Please note that only the hostname + /ipfs/ part is necessary.  
+  E.g.  
+  
+  ```
+  Correct: gateway.ipfs.io/ipfs/  
+  Wrong: gateway.ipfs.io/ipfs/bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m#x-ipfs-companion-no-redirect  
+  ```
+  
+  </details>
 Pinata IPFS Endpoints: https://www.pinata.cloud/ (IPFS_GATEWAY in pulling.py is 
 set to a public endpoint; can pull faster w Pinata)
 


### PR DESCRIPTION
I would like to propose this clarification to help new users avoid using a wrong URL when using a gateway from https://ipfs.github.io/public-gateway-checker/

[Example](https://discord.com/channels/898068711150333973/901981195045339157/904815686126276689)