### PR TITLE
Revert commit a025314 and reimplement PR #8 with additional refactoring

### DIFF
--- a/metadata/pulling.py
+++ b/metadata/pulling.py
@@ -255,15 +255,11 @@ def fetch_all_metadata(
     folder = f'{ATTRIBUTES_FOLDER}/{collection}/'
     if not os.path.exists(folder):
         os.mkdir(folder)
-    
+
     # Initiate list of dicts that will be converted to DataFrame
     dictionary_list = []
     file_suffix = ""
 
-    # Create raw attribute folder for collection if it doesnt already exist
-    folder = f'{ATTRIBUTES_FOLDER}/{collection}/'
-    if not os.path.exists(folder):
-        os.mkdir(folder)
 
     if uri_base is not None and uri_base.find("ipfs") != -1:
         folder_walk = os.walk(folder, topdown=True,

--- a/metadata/pulling.py
+++ b/metadata/pulling.py
@@ -6,7 +6,6 @@ import json
 import argparse
 import sys
 from web3 import Web3
-from web3_multicall import Multicall
 import base64
 from web3.exceptions import ContractLogicError
 import ipfshttpclient
@@ -190,23 +189,6 @@ def get_contract_uri(contract, token_id, uri_func, abi):
     except ContractLogicError as err:
         return err
 
-def get_contract_uri_batch(contract, token_ids, uri_func, abi):
-    if len(token_ids) > 0:
-        if ENDPOINT == "":
-            print("You must enter a Web3 provider. This is currently not a command line option. You must open this file and assign a valid provider to the ENDPOINT and IPFS_GATEWAY constants. See: https://ipfs.github.io/public-gateway-checker/")
-            sys.exit()
-
-        def get_func(token_id):
-            uri_contract_func = get_contract_function(contract, uri_func, abi)
-            return uri_contract_func(token_id)
-
-        w3 = Web3(Web3.HTTPProvider(ENDPOINT))
-        multicall = Multicall(w3.eth)
-        multicall_result = multicall.aggregate(list(map(get_func, token_ids)))
-        return { x["inputs"][0]["value"]: format_ipfs_uri(x["results"][0]) for x in multicall_result.json["results"]}
-    else:
-        return {}
-
 
 def get_lower_id(contract, uri_func, abi):
     # Initiate parameters
@@ -265,17 +247,42 @@ def get_metadata(uri, destination):
     return response_json
 
 
-def fetch_all_metadata(token_ids, collection, sleep, uri_func, contract, abi, uri_base, uri_suffix):
+def fetch_all_metadata(
+    token_ids, collection, sleep, uri_func, contract, abi, uri_base, uri_suffix
+):
+
+    # Create raw attribute folder for collection if it doesnt already exist
+    folder = f'{ATTRIBUTES_FOLDER}/{collection}/'
+    if not os.path.exists(folder):
+        os.mkdir(folder)
+    
     # Initiate list of dicts that will be converted to DataFrame
     dictionary_list = []
-    file_suffix = ".json"
+    file_suffix = ""
 
     # Create raw attribute folder for collection if it doesnt already exist
     folder = f'{ATTRIBUTES_FOLDER}/{collection}/'
     if not os.path.exists(folder):
         os.mkdir(folder)
 
-    def fetch(token_id, metadata_uri):
+    if uri_base is not None and uri_base.find("ipfs") != -1:
+        folder_walk = os.walk(folder, topdown=True,
+                              onerror=None, followlinks=False)
+        _files = next(folder_walk)[2]
+
+        if len(_files) == 0:
+            cid = infer_cid_from_uri(uri_base)
+            fetch_ipfs_folder(collection_name=collection,
+                              cid=cid)
+            folder_walk = os.walk(folder, topdown=True,
+                                  onerror=None, followlinks=False)
+            _files = next(folder_walk)[2]
+
+        first_file = _files[0]
+        file_suffix = get_file_suffix(first_file)
+
+    # Fetch metadata for all token ids
+    for token_id in token_ids:
         # Initiate json result
         result_json = None
 
@@ -287,7 +294,34 @@ def fetch_all_metadata(token_ids, collection, sleep, uri_func, contract, abi, ur
             # Load existing file from disk
             with open(filename, "r") as f:
                 result_json = json.load(f)
+
         else:
+
+            # Get the metadata URI
+            if uri_base is not None:
+                # Build URI from base URI and URI suffix provided
+                uri_base = format_ipfs_uri(uri_base)
+                if uri_base.endswith("/"):
+                    uri_base = uri_base[:-1]
+                if uri_base.endswith("="):
+                    metadata_uri = f"{uri_base}{token_id}"
+                else:
+                    metadata_uri = f"{uri_base}/{token_id}"
+                if uri_suffix is not None:
+                    metadata_uri += uri_suffix
+            elif uri_func is not None and contract is not None and abi is not None:
+                # Fetch URI for the given token id from the contract
+                metadata_uri = get_contract_uri(contract, token_id, uri_func, abi)
+
+                if isinstance(metadata_uri, ContractLogicError):
+                    print(f'{metadata_uri} {token_id}')
+                    continue
+
+            else:
+                raise ValueError(
+                    "Failed to get metadata URI. Must either provide a uri_base or contract"
+                )
+
             # Set parameters for retrying to pull from server
             max_retries = 5
             retries = 0
@@ -297,12 +331,16 @@ def fetch_all_metadata(token_ids, collection, sleep, uri_func, contract, abi, ur
                 try:
                     # Try to get metadata file from server
                     result_json = get_metadata(uri=metadata_uri, destination=filename)
+                    if token_id % 50 == 0:
+                        print(token_id)
                     time.sleep(sleep)
                     break
                 except Exception as err:
                     # Handle throttling, pause and then try again up to max_retries number of times
-                    print(f'Got below error when trying to get metadata for token id {token_id}. '
-                        f'Will sleep and retry...')
+                    print(
+                        f"Got below error when trying to get metadata for token id {token_id}. "
+                        f"Will sleep and retry..."
+                    )
                     print(err)
                     retries += 1
 
@@ -316,6 +354,7 @@ def fetch_all_metadata(token_ids, collection, sleep, uri_func, contract, abi, ur
                         break
 
         if result_json is not None:
+
             # TODO: What are other variations of name?
             # Add token name and token URI traits to the trait dictionary
             traits = dict()
@@ -331,9 +370,11 @@ def fetch_all_metadata(token_ids, collection, sleep, uri_func, contract, abi, ur
             elif "traits" in result_json:
                 attribute_key = "traits"
             else:
-                raise ValueError(f'Failed to find the attribute key in the token {token_id} '
-                                f'metadata result. Tried "attributes" and "traits".\nAvailable '
-                                f'keys: {result_json.keys()}')
+                raise ValueError(
+                    f"Failed to find the attribute key in the token {token_id} "
+                    f'metadata result. Tried "attributes" and "traits".\nAvailable '
+                    f"keys: {result_json.keys()}"
+                )
 
             # Add traits from the server response JSON to the traits dictionary
             try:
@@ -352,49 +393,6 @@ def fetch_all_metadata(token_ids, collection, sleep, uri_func, contract, abi, ur
                 print(
                     f"Failed to get metadata for id {token_id}. Url response was {result_json}."
                 )
-
-    if uri_base is not None:
-        # Build token URI from base URI
-        for token_id in token_ids:
-            uri_base = format_ipfs_uri(uri_base)
-            if uri_base.endswith('/'):
-                uri_base = uri_base[:-1]
-
-            if uri_base.endswith('='):
-                metadata_uri = f'{uri_base}{token_id}'
-            else:
-                metadata_uri = f'{uri_base}/{token_id}'
-
-            if uri_suffix is not None:
-                metadata_uri += uri_suffix
-
-            fetch(token_id, metadata_uri)
-    elif uri_func is not None and contract is not None and abi is not None:
-        # Fetch token URI from on-chain
-        BATCH_SIZE = 50
-        for i in range(0, len(token_ids), BATCH_SIZE):
-            print(f'Handling token id range [{i}, {i + BATCH_SIZE}]')
-            token_ids_batch = token_ids[i : min(len(token_ids), i + BATCH_SIZE)]
-
-            # Skip on-chain fetch if we already have the metadata
-            covered_token_ids = []
-            uncovered_token_ids = []
-            for token_id in token_ids_batch:
-                if os.path.exists(f'{folder}/{token_id}.json'):
-                    covered_token_ids.append(token_id)
-                else:
-                    uncovered_token_ids.append(token_id)
-
-            # For already covered token ids, use the existing local attributes
-            for token_id in covered_token_ids:
-                fetch(token_id, "")
-            
-            # For uncovered token ids, fetch the URI in bulk
-            for token_id, metadata_uri in get_contract_uri_batch(contract, uncovered_token_ids, uri_func, abi).items():
-                fetch(token_id, metadata_uri)
-    else:
-        raise ValueError(
-            'Failed to get metadata URI. Must either provide a uri_base or contract')
 
     return dictionary_list
 
@@ -531,7 +529,9 @@ def pull_metadata(args):
     print(f"Max supply: {max_supply}")
 
     # Fetch all attribute records from the remote server
-    token_ids = range(lower_id, upper_id)
+    # token_ids = range(lower_id, upper_id + 1)
+    token_ids = range(lower_id, upper_id)  # for 0-indexed collections
+
     records = fetch_all_metadata(
         token_ids=token_ids,
         collection=collection,

--- a/metadata/pulling.py
+++ b/metadata/pulling.py
@@ -313,8 +313,6 @@ def fetch_all_metadata(
             try:
                 # Try to get metadata file from server
                 get_metadata(uri=metadata_uri, destination=filename)
-                if token_id % 50 == 0:
-                    print(token_id)
                 time.sleep(sleep)
                 break
             except Exception as err:
@@ -406,6 +404,8 @@ def fetch_all_metadata(
                     "Failed to get metadata URI. Must either provide a uri_base or contract"
                 )
 
+            if token_id % 50 == 0:
+                print(token_id)
             fetch(token_id, metadata_uri, filename)
 
         if result_json is not None:

--- a/metadata/pulling.py
+++ b/metadata/pulling.py
@@ -13,17 +13,14 @@ import re
 
 ABI_ENDPOINT = "https://api.etherscan.io/api?module=contract&action=getabi&address="
 ENDPOINT = ""
-
 ATTRIBUTES_FOLDER = "raw_attributes"
 IMPLEMENTATION_SLOT = (
     "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
 )
-
-# https://ipfs.github.io/public-gateway-checker/
 IPFS_GATEWAY = ""
 
 
-""" 
+"""
 Smart contract helper methods
 """
 
@@ -442,7 +439,7 @@ def infer_cid_from_uri(uri):
 
     :param uri
     :type uri: str
-    :return: cid   
+    :return: cid
     :rtype: str | None
     """
     cid_pattern = r"Qm[a-zA-Z0-9-_]+"

--- a/metadata/pulling.py
+++ b/metadata/pulling.py
@@ -185,7 +185,7 @@ def get_contract_uri(contract, token_id, uri_func, abi):
         uri = format_ipfs_uri(uri)
         return uri
     except ContractLogicError as err:
-        return err
+        raise Exception(err)
 
 
 def get_contract_uri_batch(contract, token_ids, uri_func, abi):

--- a/metadata/pulling.py
+++ b/metadata/pulling.py
@@ -584,7 +584,6 @@ def pull_metadata(args):
     print(f"Max supply: {max_supply}")
 
     # Fetch all attribute records from the remote server
-    # token_ids = range(lower_id, upper_id + 1)
     token_ids = range(lower_id, upper_id)  # for 0-indexed collections
 
     records = fetch_all_metadata(

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "numpy>=1.18.4",
         "pandas>=1.1.5",
         "web3>=5.13.1",
+        "web3-multicall>=0.0.3",
         "requests>=2.25.1",
         "matplotlib>=3.3.4",
         "seaborn>=0.11.1",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         "numpy>=1.18.4",
         "pandas>=1.1.5",
         "web3>=5.13.1",
-        "web3-multicall>=0.0.3",
         "requests>=2.25.1",
         "matplotlib>=3.3.4",
         "seaborn>=0.11.1",


### PR DESCRIPTION
Commit https://github.com/Convex-Labs/honestnft-shenanigans/commit/a025314a35e640a68e41bfb87084909866a7801d overwrote and skipped lots of code, resulting in a broken script.

This PR first reverts the commit and then reimplements the code from @georgeroman from PR #8 and also introduces some fixes and refactoring so all methods can coexist.
With this PR the function `fetch_all_metadata` works as follow:
1. First try to get all metadata files from IPFS in bulk
2. If it fails, try to use to download metadata in batch, as implemented by @georgeroman 
3. If that fails, download all files individually