### PR TITLE
Update missing requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "requests>=2.25.1",
         "matplotlib>=3.3.4",
         "seaborn>=0.11.1",
-        "ipfshttpclient>=0.8.0a2"
+        "ipfshttpclient>=0.8.0a2",
+        "scikit-learn>=1.0.1"
     ],
 )


### PR DESCRIPTION
sklearn is used in [rarity_vs_lastprice.ipynb](https://github.com/Convex-Labs/honestnft-shenanigans/blob/master/fair_drop/rarity_vs_lastprice.ipynb) but not referenced in the requirements.