### PR TITLE
Remove deleted directory from packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ],
-    packages=["extras", "metadata", "fair_drop"],
+    packages=["metadata", "fair_drop"],
     include_package_data=True,
     install_requires=[
         "numpy>=1.18.4",


### PR DESCRIPTION
Commit e0af6816e8c63bb19fc32f8f74b037ff6910e5d7 deleted directory "extras", but it was not removed from setup.py.
Because of this it's not possible to install the dependencies from setup.py.