### PR TITLE
Refactor re-usable functions as separate module

### DIFF
--- a/metadata/pulling.py
+++ b/metadata/pulling.py
@@ -171,7 +171,7 @@ def get_contract_function(contract, func_name, abi):
         )
 
 
-def get_contract_uri(contract, token_id, uri_func, abi):
+def get_token_uri_from_contract(contract, token_id, uri_func, abi):
     # Fetch URI from contract
     uri_contract_func = get_contract_function(contract, uri_func, abi)
 
@@ -183,7 +183,7 @@ def get_contract_uri(contract, token_id, uri_func, abi):
         raise Exception(err)
 
 
-def get_contract_uri_batch(contract, token_ids, uri_func, abi):
+def get_token_uri_from_contract_batch(contract, token_ids, uri_func, abi):
     if len(token_ids) > 0:
         if config.ENDPOINT == "":
             print(
@@ -206,7 +206,7 @@ def get_contract_uri_batch(contract, token_ids, uri_func, abi):
         return {}
 
 
-def get_lower_id(contract, uri_func, abi):
+def get_lower_token_id(contract, uri_func, abi):
     # Initiate parameters
     lower_token_id = None
 
@@ -214,7 +214,7 @@ def get_lower_id(contract, uri_func, abi):
     for token_id in [0, 1]:
         try:
             # Fetch the metadata url from the contract
-            uri = get_contract_uri(contract, token_id, uri_func, abi)
+            uri = get_token_uri_from_contract(contract, token_id, uri_func, abi)
             print(f"Metadata for lower bound token id is at: {uri}")
             lower_token_id = token_id
             break
@@ -282,7 +282,7 @@ def fetch_all_metadata(
         for token_id in [0, 1]:
             try:
                 # Fetch the metadata url from the contract
-                uri = get_contract_uri(contract, token_id, uri_func, abi)
+                uri = get_token_uri_from_contract(contract, token_id, uri_func, abi)
                 break
             except Exception as err:
                 pass
@@ -366,7 +366,7 @@ def fetch_all_metadata(
                     token_ids_batch,
                 )
             )
-            for token_id, metadata_uri in get_contract_uri_batch(
+            for token_id, metadata_uri in get_token_uri_from_contract_batch(
                 contract, token_ids_batch, uri_func, abi
             ).items():
                 fetch(
@@ -407,7 +407,9 @@ def fetch_all_metadata(
                     metadata_uri += uri_suffix
             elif uri_func is not None and contract is not None and abi is not None:
                 # Fetch URI for the given token id from the contract
-                metadata_uri = get_contract_uri(contract, token_id, uri_func, abi)
+                metadata_uri = get_token_uri_from_contract(
+                    contract, token_id, uri_func, abi
+                )
 
                 if isinstance(metadata_uri, ContractLogicError):
                     print(f"{metadata_uri} {token_id}")
@@ -499,7 +501,9 @@ def pull_metadata(args):
     # Get the lower bound token id of the contract
     if args.lower_id is None and contract is not None and abi is not None:
         # Lower id not provided so will infer it from the contract object
-        lower_id = get_lower_id(contract=contract, uri_func=args.uri_func, abi=abi)
+        lower_id = get_lower_token_id(
+            contract=contract, uri_func=args.uri_func, abi=abi
+        )
     elif args.lower_id is not None:
         # Setting lower id as provided
         lower_id = args.lower_id

--- a/metadata/pulling.py
+++ b/metadata/pulling.py
@@ -99,6 +99,7 @@ def fetch_all_metadata(
                 file_suffix = ipfs.get_file_suffix(first_file)
                 bulk_ipfs_success = True
             except Exception:
+                print("Falling back to individual file downloads...")
                 file_suffix = ".json"
                 pass
     else:

--- a/metadata/pulling.py
+++ b/metadata/pulling.py
@@ -1,16 +1,19 @@
-import os, sys
-
-sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+import argparse
+import base64
+import json
+import os
+import sys
+import time
 
 import pandas as pd
 import requests
-import time
-import json
-import argparse
-import base64
 from web3.exceptions import ContractLogicError
 
-from utils import chain, config, ipfs
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+
+from utils import chain
+from utils import config
+from utils import ipfs
 
 
 """

--- a/metadata/pulling.py
+++ b/metadata/pulling.py
@@ -8,227 +8,9 @@ import time
 import json
 import argparse
 import base64
-from web3 import Web3
 from web3.exceptions import ContractLogicError
-from web3_multicall import Multicall
 
-from utils import config, ipfs
-
-"""
-Smart contract helper methods
-"""
-
-
-def get_contract_abi(address):
-    # Get contract ABI
-    abi_url = f"{config.ABI_ENDPOINT}{address}"
-    response = requests.get(abi_url)
-    try:
-        abi = json.loads(response.json()["result"])
-        return abi
-    except Exception as err:
-        print(f"Failed to get contract ABI from Etherscan: {err}")
-        print(f"Falling back to direct ABI checking")
-        if config.ENDPOINT != "":
-            # We can check the ABI of non-verified Etherscan contracts
-            # if they support ERC165 (which most of them do)
-            erc165_abi = [
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes4",
-                            "name": "interfaceId",
-                            "type": "bytes4",
-                        }
-                    ],
-                    "name": "supportsInterface",
-                    "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
-                    "stateMutability": "view",
-                    "type": "function",
-                }
-            ]
-
-            w3 = Web3(Web3.HTTPProvider(config.ENDPOINT))
-            contract = w3.eth.contract(Web3.toChecksumAddress(address), abi=erc165_abi)
-
-            # Array of contract methods that were verified via ERC165
-            contract_abi = []
-
-            # List of common ERC721 methods to check
-            common_abis = {}
-            # ERC721 metadata interface id
-            common_abis["0x5b5e139f"] = [
-                {
-                    "inputs": [],
-                    "name": "name",
-                    "outputs": [
-                        {"internalType": "string", "name": "", "type": "string"}
-                    ],
-                    "stateMutability": "view",
-                    "type": "function",
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "uint256",
-                            "name": "tokenId",
-                            "type": "uint256",
-                        }
-                    ],
-                    "name": "tokenURI",
-                    "outputs": [
-                        {"internalType": "string", "name": "", "type": "string"}
-                    ],
-                    "stateMutability": "view",
-                    "type": "function",
-                },
-            ]
-            # ERC721 enumerable interface id
-            common_abis["0x780e9d63"] = [
-                {
-                    "inputs": [],
-                    "name": "totalSupply",
-                    "outputs": [
-                        {"internalType": "uint256", "name": "", "type": "uint256"}
-                    ],
-                    "stateMutability": "view",
-                    "type": "function",
-                }
-            ]
-
-            for selector, abi in common_abis.items():
-                try:
-                    supports_abi = contract.functions.supportsInterface(selector).call()
-                    if supports_abi:
-                        contract_abi += abi
-                except Exception as err:
-                    print(f"Could not check selector {selector}")
-
-            if len(contract_abi) > 0:
-                return contract_abi
-
-        raise Exception(
-            f"Failed to get contract ABI.\nURL: {abi_url}\nResponse: {response.json()}"
-        )
-
-
-def get_contract(address, abi):
-    # Connect to web3
-    if config.ENDPOINT == "":
-        print(
-            "\nMust enter a Web3 provider. Open this file and set the ENDPOINT and IPFS_GATEWAY constants. See: https://ipfs.github.io/public-gateway-checker/\n"
-        )
-        print("Optional: Use -web3_provider as a command line argument")
-        sys.exit()
-
-    w3 = Web3(Web3.HTTPProvider(config.ENDPOINT))
-
-    # Check if abi contains the tokenURI function
-    contract_functions = [func["name"] for func in abi if "name" in func]
-
-    if "implementation" in contract_functions:
-        # Handle case where the contract is a proxy contract
-        # Fetch address for the implementation contract
-        impl_contract = w3.toHex(
-            w3.eth.get_storage_at(address, config.IMPLEMENTATION_SLOT)
-        )
-
-        # Strip the padded zeros from the implementation contract address
-        impl_address = "0x" + impl_contract[-40:]
-        print(
-            f"Contract is a proxy contract. Using implementation address: {impl_address}"
-        )
-
-        # Sleep to respect etherscan API limit
-        time.sleep(5)
-
-        # Get the implementation contract ABI
-        impl_abi = get_contract_abi(address=impl_address)
-
-        # Return the implementation contract object instead
-        return get_contract(impl_contract, abi=impl_abi)
-
-    # Get contract checksum address
-    contract_checksum = Web3.toChecksumAddress(address)
-
-    # Build the Ethereum contract object
-    collection_contract = w3.eth.contract(contract_checksum, abi=abi)
-
-    # Return the contract ABI and Ethereum contract object
-    return abi, collection_contract
-
-
-def get_contract_function(contract, func_name, abi):
-    if func_name in dir(contract.functions):
-        # The function name given is a valid function in the ABI, so return that function
-        return getattr(contract.functions, func_name)
-    else:
-        # The function name provided is not in the contract ABI, so throw an error
-        func_names = [f["name"] for f in abi if "name" in f]
-        raise ValueError(
-            f"{func_name} is not in the contract ABI. Inspect the following function names "
-            f"for candidates and pass to the command line arguments: {func_names}"
-        )
-
-
-def get_token_uri_from_contract(contract, token_id, uri_func, abi):
-    # Fetch URI from contract
-    uri_contract_func = get_contract_function(contract, uri_func, abi)
-
-    try:
-        uri = uri_contract_func(token_id).call()
-        uri = ipfs.format_ipfs_uri(uri)
-        return uri
-    except ContractLogicError as err:
-        raise Exception(err)
-
-
-def get_token_uri_from_contract_batch(contract, token_ids, uri_func, abi):
-    if len(token_ids) > 0:
-        if config.ENDPOINT == "":
-            print(
-                "You must enter a Web3 provider. This is currently not a command line option. You must open this file and assign a valid provider to the ENDPOINT and IPFS_GATEWAY constants. See: https://ipfs.github.io/public-gateway-checker/"
-            )
-            sys.exit()
-
-        def get_func(token_id):
-            uri_contract_func = get_contract_function(contract, uri_func, abi)
-            return uri_contract_func(token_id)
-
-        w3 = Web3(Web3.HTTPProvider(config.ENDPOINT))
-        multicall = Multicall(w3.eth)
-        multicall_result = multicall.aggregate(list(map(get_func, token_ids)))
-        return {
-            x["inputs"][0]["value"]: ipfs.format_ipfs_uri(x["results"][0])
-            for x in multicall_result.json["results"]
-        }
-    else:
-        return {}
-
-
-def get_lower_token_id(contract, uri_func, abi):
-    # Initiate parameters
-    lower_token_id = None
-
-    # Search over possible lower bound ids
-    for token_id in [0, 1]:
-        try:
-            # Fetch the metadata url from the contract
-            uri = get_token_uri_from_contract(contract, token_id, uri_func, abi)
-            print(f"Metadata for lower bound token id is at: {uri}")
-            lower_token_id = token_id
-            break
-        except Exception as err:
-            # Catch exception where token URI function fails because the token id is invalid
-            print(err)
-            pass
-
-    # Raise exception if method fails to find the metadata url
-    if lower_token_id is None:
-        raise Exception("Unable to get the metadata url.")
-
-    # Return lower id
-    return lower_token_id
+from utils import chain, config, ipfs
 
 
 """
@@ -282,7 +64,9 @@ def fetch_all_metadata(
         for token_id in [0, 1]:
             try:
                 # Fetch the metadata url from the contract
-                uri = get_token_uri_from_contract(contract, token_id, uri_func, abi)
+                uri = chain.get_token_uri_from_contract(
+                    contract, token_id, uri_func, abi
+                )
                 break
             except Exception as err:
                 pass
@@ -366,7 +150,7 @@ def fetch_all_metadata(
                     token_ids_batch,
                 )
             )
-            for token_id, metadata_uri in get_token_uri_from_contract_batch(
+            for token_id, metadata_uri in chain.get_token_uri_from_contract_batch(
                 contract, token_ids_batch, uri_func, abi
             ).items():
                 fetch(
@@ -407,7 +191,7 @@ def fetch_all_metadata(
                     metadata_uri += uri_suffix
             elif uri_func is not None and contract is not None and abi is not None:
                 # Fetch URI for the given token id from the contract
-                metadata_uri = get_token_uri_from_contract(
+                metadata_uri = chain.get_token_uri_from_contract(
                     contract, token_id, uri_func, abi
                 )
 
@@ -477,8 +261,8 @@ def pull_metadata(args):
 
     if args.contract is not None:
         # Get Ethereum contract object
-        abi = get_contract_abi(address=args.contract)
-        abi, contract = get_contract(address=args.contract, abi=abi)
+        abi = chain.get_contract_abi(address=args.contract)
+        abi, contract = chain.get_contract(address=args.contract, abi=abi)
     else:
         contract = None
         abi = None
@@ -486,7 +270,7 @@ def pull_metadata(args):
     # Get the max supply of the contract
     if args.max_supply is None and contract is not None and abi is not None:
         # Supply function not provided so will infer max supply from the contract object
-        supply_func = get_contract_function(
+        supply_func = chain.get_contract_function(
             contract=contract, func_name=args.supply_func, abi=abi
         )
         max_supply = supply_func().call()
@@ -501,7 +285,7 @@ def pull_metadata(args):
     # Get the lower bound token id of the contract
     if args.lower_id is None and contract is not None and abi is not None:
         # Lower id not provided so will infer it from the contract object
-        lower_id = get_lower_token_id(
+        lower_id = chain.get_lower_token_id(
             contract=contract, uri_func=args.uri_func, abi=abi
         )
     elif args.lower_id is not None:
@@ -524,7 +308,7 @@ def pull_metadata(args):
 
     # Get collection name
     if args.collection is None and contract is not None and abi is not None:
-        name_func = get_contract_function(
+        name_func = chain.get_contract_function(
             contract=contract, func_name=args.name_func, abi=abi
         )
         collection = name_func().call()

--- a/snippets/is_contract_metadata_decentralised.py
+++ b/snippets/is_contract_metadata_decentralised.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+
+from utils import chain, ipfs
+
+contract_address = "0x60d9b4f9d85695274a5777537f204675082bd745"
+
+abi = chain.get_contract_abi(address=contract_address)
+abi, contract = chain.get_contract(address=contract_address, abi=abi)
+
+try:
+    base_uri = chain.get_base_uri(contract=contract, abi=abi)
+    print(ipfs.is_valid_ipfs_uri(base_uri))
+except Exception as err:
+    print("Failed to get base URI")
+    print("Trying to infer baseURI from tokenURI")
+    for token_id in [0, 1]:
+        try:
+            # Fetch the metadata url from the contract
+            uri = chain.get_token_uri_from_contract(contract, token_id, "tokenURI", abi)
+            if ipfs.is_valid_ipfs_uri(uri):
+                print("This file is hosted on IPFS")
+            else:
+                print("This file is not hosted on IPFS")
+                print(uri)
+            break
+        except Exception as err:
+            pass

--- a/utils/chain.py
+++ b/utils/chain.py
@@ -20,7 +20,7 @@ def get_contract_abi(address):
         return abi
     except Exception as err:
         print(f"Failed to get contract ABI from Etherscan: {err}")
-        print(f"Falling back to direct ABI checking")
+        print("Falling back to direct ABI checking")
         if config.ENDPOINT != "":
             # We can check the ABI of non-verified Etherscan contracts
             # if they support ERC165 (which most of them do)

--- a/utils/chain.py
+++ b/utils/chain.py
@@ -1,0 +1,223 @@
+import json
+import sys
+import time
+
+import requests
+from web3 import Web3
+from web3.exceptions import ContractLogicError
+from web3_multicall import Multicall
+
+import utils.config as config
+import utils.ipfs as ipfs
+
+
+def get_contract_abi(address):
+    # Get contract ABI
+    abi_url = f"{config.ABI_ENDPOINT}{address}"
+    response = requests.get(abi_url)
+    try:
+        abi = json.loads(response.json()["result"])
+        return abi
+    except Exception as err:
+        print(f"Failed to get contract ABI from Etherscan: {err}")
+        print(f"Falling back to direct ABI checking")
+        if config.ENDPOINT != "":
+            # We can check the ABI of non-verified Etherscan contracts
+            # if they support ERC165 (which most of them do)
+            erc165_abi = [
+                {
+                    "inputs": [
+                        {
+                            "internalType": "bytes4",
+                            "name": "interfaceId",
+                            "type": "bytes4",
+                        }
+                    ],
+                    "name": "supportsInterface",
+                    "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+                    "stateMutability": "view",
+                    "type": "function",
+                }
+            ]
+
+            w3 = Web3(Web3.HTTPProvider(config.ENDPOINT))
+            contract = w3.eth.contract(Web3.toChecksumAddress(address), abi=erc165_abi)
+
+            # Array of contract methods that were verified via ERC165
+            contract_abi = []
+
+            # List of common ERC721 methods to check
+            common_abis = {}
+            # ERC721 metadata interface id
+            common_abis["0x5b5e139f"] = [
+                {
+                    "inputs": [],
+                    "name": "name",
+                    "outputs": [
+                        {"internalType": "string", "name": "", "type": "string"}
+                    ],
+                    "stateMutability": "view",
+                    "type": "function",
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "uint256",
+                            "name": "tokenId",
+                            "type": "uint256",
+                        }
+                    ],
+                    "name": "tokenURI",
+                    "outputs": [
+                        {"internalType": "string", "name": "", "type": "string"}
+                    ],
+                    "stateMutability": "view",
+                    "type": "function",
+                },
+            ]
+            # ERC721 enumerable interface id
+            common_abis["0x780e9d63"] = [
+                {
+                    "inputs": [],
+                    "name": "totalSupply",
+                    "outputs": [
+                        {"internalType": "uint256", "name": "", "type": "uint256"}
+                    ],
+                    "stateMutability": "view",
+                    "type": "function",
+                }
+            ]
+
+            for selector, abi in common_abis.items():
+                try:
+                    supports_abi = contract.functions.supportsInterface(selector).call()
+                    if supports_abi:
+                        contract_abi += abi
+                except Exception as err:
+                    print(f"Could not check selector {selector}")
+
+            if len(contract_abi) > 0:
+                return contract_abi
+
+        raise Exception(
+            f"Failed to get contract ABI.\nURL: {abi_url}\nResponse: {response.json()}"
+        )
+
+
+def get_contract(address, abi):
+    # Connect to web3
+    if config.ENDPOINT == "":
+        print(
+            "\nMust enter a Web3 provider. Open this file and set the ENDPOINT and IPFS_GATEWAY constants. See: https://ipfs.github.io/public-gateway-checker/\n"
+        )
+        print("Optional: Use -web3_provider as a command line argument")
+        sys.exit()
+
+    w3 = Web3(Web3.HTTPProvider(config.ENDPOINT))
+
+    # Check if abi contains the tokenURI function
+    contract_functions = [func["name"] for func in abi if "name" in func]
+
+    if "implementation" in contract_functions:
+        # Handle case where the contract is a proxy contract
+        # Fetch address for the implementation contract
+        impl_contract = w3.toHex(
+            w3.eth.get_storage_at(address, config.IMPLEMENTATION_SLOT)
+        )
+
+        # Strip the padded zeros from the implementation contract address
+        impl_address = "0x" + impl_contract[-40:]
+        print(
+            f"Contract is a proxy contract. Using implementation address: {impl_address}"
+        )
+
+        # Sleep to respect etherscan API limit
+        time.sleep(5)
+
+        # Get the implementation contract ABI
+        impl_abi = get_contract_abi(address=impl_address)
+
+        # Return the implementation contract object instead
+        return get_contract(impl_contract, abi=impl_abi)
+
+    # Get contract checksum address
+    contract_checksum = Web3.toChecksumAddress(address)
+
+    # Build the Ethereum contract object
+    collection_contract = w3.eth.contract(contract_checksum, abi=abi)
+
+    # Return the contract ABI and Ethereum contract object
+    return abi, collection_contract
+
+
+def get_contract_function(contract, func_name, abi):
+    if func_name in dir(contract.functions):
+        # The function name given is a valid function in the ABI, so return that function
+        return getattr(contract.functions, func_name)
+    else:
+        # The function name provided is not in the contract ABI, so throw an error
+        func_names = [f["name"] for f in abi if "name" in f]
+        raise ValueError(
+            f"{func_name} is not in the contract ABI. Inspect the following function names "
+            f"for candidates and pass to the command line arguments: {func_names}"
+        )
+
+
+def get_token_uri_from_contract(contract, token_id, uri_func, abi):
+    # Fetch URI from contract
+    uri_contract_func = get_contract_function(contract, uri_func, abi)
+
+    try:
+        uri = uri_contract_func(token_id).call()
+        uri = ipfs.format_ipfs_uri(uri)
+        return uri
+    except ContractLogicError as err:
+        raise Exception(err)
+
+
+def get_token_uri_from_contract_batch(contract, token_ids, uri_func, abi):
+    if len(token_ids) > 0:
+        if config.ENDPOINT == "":
+            print(
+                "You must enter a Web3 provider. This is currently not a command line option. You must open this file and assign a valid provider to the ENDPOINT and IPFS_GATEWAY constants. See: https://ipfs.github.io/public-gateway-checker/"
+            )
+            sys.exit()
+
+        def get_func(token_id):
+            uri_contract_func = get_contract_function(contract, uri_func, abi)
+            return uri_contract_func(token_id)
+
+        w3 = Web3(Web3.HTTPProvider(config.ENDPOINT))
+        multicall = Multicall(w3.eth)
+        multicall_result = multicall.aggregate(list(map(get_func, token_ids)))
+        return {
+            x["inputs"][0]["value"]: ipfs.format_ipfs_uri(x["results"][0])
+            for x in multicall_result.json["results"]
+        }
+    else:
+        return {}
+
+
+def get_lower_token_id(contract, uri_func, abi):
+    # Initiate parameters
+    lower_token_id = None
+
+    # Search over possible lower bound ids
+    for token_id in [0, 1]:
+        try:
+            # Fetch the metadata url from the contract
+            uri = get_token_uri_from_contract(contract, token_id, uri_func, abi)
+            print(f"Metadata for lower bound token id is at: {uri}")
+            lower_token_id = token_id
+            break
+        except Exception as err:
+            # Catch exception where token URI function fails because the token id is invalid
+            print(err)
+            pass
+
+    # Raise exception if method fails to find the metadata url
+    if lower_token_id is None:
+        raise Exception("Unable to get the metadata url.")
+
+    # Return lower id
+    return lower_token_id

--- a/utils/chain.py
+++ b/utils/chain.py
@@ -221,3 +221,13 @@ def get_lower_token_id(contract, uri_func, abi):
 
     # Return lower id
     return lower_token_id
+
+
+def get_base_uri(contract, abi):
+    uri_contract_func = get_contract_function(contract, "baseURI", abi)
+
+    try:
+        uri = uri_contract_func().call()
+        return uri
+    except ContractLogicError as err:
+        raise Exception(err)

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,0 +1,7 @@
+ABI_ENDPOINT = "https://api.etherscan.io/api?module=contract&action=getabi&address="
+ENDPOINT = ""
+ATTRIBUTES_FOLDER = "raw_attributes"
+IMPLEMENTATION_SLOT = (
+    "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
+)
+IPFS_GATEWAY = ""

--- a/utils/ipfs.py
+++ b/utils/ipfs.py
@@ -19,11 +19,16 @@ def get_file_suffix(filename, token_id="\\d+"):
     :return: file_suffix
     :rtype: str
     """
-    regex = rf"^{token_id}(\.(?P<extension>\w+))?$"
-    matches = re.search(regex, filename)
-    if matches and matches.group("extension"):
-        return matches.group(1)
-    return ""
+    token_id_pattern = rf"^{token_id}"
+    matches = re.search(token_id_pattern, filename)
+    if matches:
+        regex = rf"^{token_id}(\.(?P<extension>\w+))?$"
+        matches = re.search(regex, filename)
+        if matches and matches.group("extension"):
+            return matches.group(1)
+        return ""
+    else:
+        raise ValueError("Provided token_id not found in filename")
 
 
 def infer_cid_from_uri(uri):

--- a/utils/ipfs.py
+++ b/utils/ipfs.py
@@ -86,7 +86,7 @@ def fetch_ipfs_folder(collection_name, cid, parent_folder, timeout=60):
         try:
             client = ipfshttpclient.connect(addr=gateways[gateway], timeout=timeout)
             client.get(f"/ipfs/{cid}", target=f"{os.getcwd()}/{parent_folder}/")
-            print(f"Successfully downloaded metadata folder from IPFS")
+            print("Successfully downloaded metadata folder from IPFS")
             os.rename(
                 f"./{parent_folder}/{cid}",
                 f"./{parent_folder}/{collection_name}",

--- a/utils/ipfs.py
+++ b/utils/ipfs.py
@@ -79,7 +79,7 @@ def fetch_ipfs_folder(collection_name, cid, parent_folder, timeout=60):
     warnings.filterwarnings(
         "ignore", category=ipfshttpclient.exceptions.VersionMismatch
     )
-    gateways = [ipfs_gateway_io, infura, dweb_link, ipfs_io, pinata]
+    gateways = [pinata, ipfs_gateway_io, infura, dweb_link, ipfs_io]
     print("Attempting to download metadata folder from IPFS...\nPlease wait...")
 
     for gateway in range(len(gateways)):
@@ -99,9 +99,12 @@ def fetch_ipfs_folder(collection_name, cid, parent_folder, timeout=60):
                     "Failed to download metadata folder from IPFS. Trying next gateway..."
                 )
             else:
-                print(
-                    "Failed to download metadata folder from IPFS.\nFalling back to individual file downloads..."
-                )
+                print("Failed to download metadata folder from IPFS.")
+                if os.path.exists(f"./{parent_folder}/{cid}"):
+                    os.rename(
+                        f"./{parent_folder}/{cid}",
+                        f"./{parent_folder}/{collection_name}",
+                    )
             pass
 
 

--- a/utils/ipfs.py
+++ b/utils/ipfs.py
@@ -1,0 +1,129 @@
+import os
+import re
+import warnings
+
+import ipfshttpclient
+
+import utils.config as config
+
+
+def get_file_suffix(filename, token_id="\\d+"):
+    """
+    Given a filename and an optional token_id, this function returns the file suffix.
+    If the file has no extension, an empty string is returned.
+
+    :param filename
+    :type filename: str
+    :param token_id
+    :type token_id: str | int | None
+    :return: file_suffix
+    :rtype: str
+    """
+    regex = rf"^{token_id}(\.(?P<extension>\w+))?$"
+    matches = re.search(regex, filename)
+    if matches and matches.group("extension"):
+        return matches.group(1)
+    return ""
+
+
+def infer_cid_from_uri(uri):
+    """
+    Given a URI, this function returns the CID.
+    Returns None if the CID is not found.
+
+    :param uri
+    :type uri: str
+    :return: cid
+    :rtype: str | None
+    """
+    cid_pattern = r"Qm[a-zA-Z0-9-_]+"
+    matches = re.search(cid_pattern, uri)
+    if matches:
+        return matches.group(0)
+    return None
+
+
+def is_valid_ipfs_uri(uri):
+    """
+    Given a URI, this functions checks if it's a valid IPFS URI.
+
+    :param uri
+    :type uri: str
+    :rtype: bool
+    """
+    if uri.find("ipfs") != -1 and infer_cid_from_uri(uri):
+        return True
+    return False
+
+
+def fetch_ipfs_folder(collection_name, cid, parent_folder, timeout=60):
+    # print(os.getcwd())
+    # print(f"{os.getcwd()}/{parent_folder}/")
+    """
+    Given a collection name, a cid and an optional timeout, this function downloads the entire metadata folder from IPFS.
+
+    :param parent_folder: The parent folder where the collection should be saved.
+    :type parent_folder:  str
+    :param collection_name The collection name to be used as the folder name
+    :type collection_name: str
+    :param cid: The IPFS CID of folder to download
+    :type cid: str
+    :param timeout: Connection timeout (in seconds) when connecting to the API daemon
+    :type timeout: int | None
+    """
+    infura = "/dns/infura-ipfs.io/tcp/5001/https"
+    ipfs_io = "/dns/ipfs.io/tcp/443/https"
+    ipfs_gateway_io = "/dns/gateway.ipfs.io/tcp/443/https"
+    dweb_link = "/dns/dweb.link/tcp/443/https"
+    pinata = "/dns/gateway.pinata.cloud/tcp/443/https"
+    warnings.filterwarnings(
+        "ignore", category=ipfshttpclient.exceptions.VersionMismatch
+    )
+    gateways = [ipfs_gateway_io, infura, dweb_link, ipfs_io, pinata]
+    print("Attempting to download metadata folder from IPFS...\nPlease wait...")
+
+    for gateway in range(len(gateways)):
+        try:
+            client = ipfshttpclient.connect(addr=gateways[gateway], timeout=timeout)
+            client.get(f"/ipfs/{cid}", target=f"{os.getcwd()}/{parent_folder}/")
+            print(f"Successfully downloaded metadata folder from IPFS")
+            os.rename(
+                f"./{parent_folder}/{cid}",
+                f"./{parent_folder}/{collection_name}",
+            )
+            client.close()
+            break
+        except Exception:
+            if gateway < len(gateways) - 1:
+                print(
+                    "Failed to download metadata folder from IPFS. Trying next gateway..."
+                )
+            else:
+                print(
+                    "Failed to download metadata folder from IPFS.\nFalling back to individual file downloads..."
+                )
+            pass
+
+
+def format_ipfs_uri(uri):
+    # Reformat IPFS gateway
+    ipfs_1 = "ipfs://"
+    ipfs_2 = "https://ipfs.io/ipfs/"
+    ipfs_3 = "https://gateway.pinata.cloud/ipfs/"
+    ipfs_hash_identifier = "Qm"
+
+    if config.IPFS_GATEWAY == "":
+        if uri.startswith(ipfs_1):
+            uri = ipfs_2 + uri[len(ipfs_1) :]
+    else:
+        if uri.startswith(ipfs_1):
+            uri = config.IPFS_GATEWAY + uri[len(ipfs_1) :]
+        elif uri.startswith(ipfs_2):
+            uri = config.IPFS_GATEWAY + uri[len(ipfs_2) :]
+        elif uri.startswith(ipfs_3):
+            uri = config.IPFS_GATEWAY + uri[len(ipfs_3) :]
+        elif "pinata" in uri:
+            starting_index_of_hash = uri.find(ipfs_hash_identifier)
+            uri = config.IPFS_GATEWAY + uri[starting_index_of_hash:]
+
+    return uri


### PR DESCRIPTION
With this PR, I propose to use a more modular approach to functions that might be or are re-used in other scripts.
In the root directory there is a directory named `utils` with different python files, each for a specific part of the workflow. 
* `ipfs.py` for IPFS related functions
* `chain.py` for on-chain related functions
* `config.py` to store global variables 

I have also added a folder to store example scripts that don't fit in the current workflow, but might be of interest for others or for later use. 