### PR TITLE
Add support for Polygon

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -1,5 +1,9 @@
 ABI_ENDPOINT = "https://api.etherscan.io/api?module=contract&action=getabi&address="
+POLYGON_ABI_ENDPOINT = (
+    "https://api.polygonscan.com/api?module=contract&action=getabi&address="
+)
 ENDPOINT = ""
+POLYGON_ENDPOINT = ""
 ATTRIBUTES_FOLDER = "raw_attributes"
 IMPLEMENTATION_SLOT = (
     "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"


### PR DESCRIPTION
This PR introduces partial support for interacting with contracts on Polygon and pulling metadata.

* `get_token_uri_from_contract_batch()` is currently not supported due to a limitation in web3.py
Additional error handling has been added to pulling.py so it falls back on `get_token_uri_from_contract`, without failing.
* an additional argument `-chain` has been added to pulling.py to switch to another chain. (defaults to ethereum for backwards compatibility)
* A new `POLYGON_ENDPOINT` has to be registered on Alchemy 

Example:
`python3 pulling.py -contract 0x82bbf7be0eb9a6024b7a641ba179e00812bdae53 -chain polygon`
