### PR TITLE
Replace web3-multicall by multicall

### DIFF
--- a/metadata/pulling.py
+++ b/metadata/pulling.py
@@ -143,6 +143,7 @@ def fetch_all_metadata(
         and abi is not None
     ):
         try:
+            function_signature = chain.get_function_signature(uri_func, abi)
             # Fetch token URI from on-chain
             BATCH_SIZE = 50
             for i in range(0, len(token_ids), BATCH_SIZE):
@@ -158,7 +159,7 @@ def fetch_all_metadata(
                     )
                 )
                 for token_id, metadata_uri in chain.get_token_uri_from_contract_batch(
-                    contract, token_ids_batch, uri_func, abi
+                    contract, token_ids_batch, function_signature, abi
                 ).items():
                     fetch(
                         token_id,

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,11 @@ setup(
         "numpy>=1.18.4",
         "pandas>=1.1.5",
         "web3>=5.13.1",
-        "web3-multicall>=0.0.3",
         "requests>=2.25.1",
         "matplotlib>=3.3.4",
         "seaborn>=0.11.1",
         "ipfshttpclient>=0.8.0a2",
         "scikit-learn>=1.0.1",
+        "multicall>=0.1.3",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
         "seaborn>=0.11.1",
         "ipfshttpclient>=0.8.0a2",
         "scikit-learn>=1.0.1",
-        "multicall>=0.1.3",
+        "multicall>=0.2.0",
     ],
 )

--- a/utils/chain.py
+++ b/utils/chain.py
@@ -3,9 +3,9 @@ import sys
 import time
 
 import requests
+from multicall import Call, Multicall
 from web3 import Web3
 from web3.exceptions import ContractLogicError
-from web3_multicall import Multicall
 
 import utils.config as config
 import utils.ipfs as ipfs
@@ -192,7 +192,7 @@ def get_token_uri_from_contract(contract, token_id, uri_func, abi):
 
 
 def get_token_uri_from_contract_batch(
-    contract, token_ids, uri_func, abi, chain="ethereum"
+    contract, token_ids, function_signature, abi, chain="ethereum"
 ):
     if chain == "ethereum":
         endpoint = config.ENDPOINT
@@ -209,17 +209,21 @@ def get_token_uri_from_contract_batch(
             )
             sys.exit()
 
-        def get_func(token_id):
-            uri_contract_func = get_contract_function(contract, uri_func, abi)
-            return uri_contract_func(token_id)
+        # signature = get_function_signature(uri_func, abi)
 
         w3 = Web3(Web3.HTTPProvider(endpoint))
-        multicall = Multicall(w3.eth)
-        multicall_result = multicall.aggregate(list(map(get_func, token_ids)))
-        return {
-            x["inputs"][0]["value"]: ipfs.format_ipfs_uri(x["results"][0])
-            for x in multicall_result.json["results"]
-        }
+
+        calls = []
+        for token_id in token_ids:
+            call = Call(
+                target=contract.address,
+                function=[function_signature, token_id],
+                returns=[[token_id, ipfs.format_ipfs_uri]],
+            )
+            calls.append(call)
+        multi = Multicall(calls, _w3=w3)
+        return multi()
+
     else:
         return {}
 
@@ -257,3 +261,25 @@ def get_base_uri(contract, abi):
         return uri
     except ContractLogicError as err:
         raise Exception(err)
+
+
+def get_function_signature(func_name, abi):
+    """
+    Given a function name and an ABI, return the function signature
+    e.g. get_function_signature("tokenURI", abi) => "tokenURI(uint256)(string)"
+
+    :param func_name:
+    :type func_name: str
+    :param abi:
+    :type abi: list
+    :return: function signature
+    :rtype: str
+    """
+    filtered = list(
+        filter(
+            lambda d: d["name"] == func_name if d["type"] == "function" else None, abi
+        )
+    )[0]
+    input_types = [obj["type"] for obj in filtered["inputs"]]
+    output_types = [obj["type"] for obj in filtered["outputs"]]
+    return f"{func_name}({','.join(input_types)})({','.join(output_types)})"


### PR DESCRIPTION
This PR replaces our dependency on [web3-multicall](https://github.com/kkristof200/py_web3_multicall) by [multicall](https://github.com/banteg/multicall.py).
Reason is mostly for security considerations and amount of community support.
I've talked this over with @georgeroman who originally wrote the batch function.

* Update dependencies
* Implement get_function_signature
* Replace web3-multicall by multicall