### PR TITLE
Implement token standard detection for contracts

### DIFF
--- a/utils/chain.py
+++ b/utils/chain.py
@@ -70,7 +70,9 @@ def get_contract_abi(address, blockchain="ethereum"):
 
             # List of common ERC721 methods to check
             common_abis = {}
-            # ERC721 metadata interface id
+            # ERC165 interface ID
+            common_abis["0x01ffc9a7"] = erc165_abi
+            # ERC721 metadata interface ID
             common_abis["0x5b5e139f"] = [
                 {
                     "inputs": [],
@@ -97,7 +99,7 @@ def get_contract_abi(address, blockchain="ethereum"):
                     "type": "function",
                 },
             ]
-            # ERC721 enumerable interface id
+            # ERC721 enumerable interface ID
             common_abis["0x780e9d63"] = [
                 {
                     "inputs": [],
@@ -317,3 +319,24 @@ def get_function_signature(func_name, abi):
     input_types = [obj["type"] for obj in filtered["inputs"]]
     output_types = [obj["type"] for obj in filtered["outputs"]]
     return f"{func_name}({','.join(input_types)})({','.join(output_types)})"
+
+
+def get_token_standard(contract):
+    """
+    Given a contract object, return the token standard
+    eg. get_token_standard(contract) => "ERC-721"
+
+    :param contract:
+    :type contract: web3.contract.Contract
+    :return: ERC standard
+    :rtype: str
+    """
+    erc_dict = {
+        "ERC-721": ["0x80AC58CD", "0x150B7A02", "0x5B5E139F"],
+        "ERC-1155": ["0xD9B67A26", "0x4E2312E0"],
+    }
+    for standard, identifiers in erc_dict.items():
+        for identifier in identifiers:
+            if contract.functions.supportsInterface(identifier).call():
+                return standard
+    return "Unknown standard"


### PR DESCRIPTION
This PR introduces the ability to detect if a contract is either a ERC-721 or ERC-1155 type.

Example:
```python
quaks_address_erc721 = "0x07bbdaf30e89ea3ecf6cadc80d6e7c4b0843c729"
rarible_address_erc1155 = "0xd07dc4262bcdbf85190c01c996b4c06a461d2430"

print("testing quaks. Should be ERC-721")
abi = chain.get_contract_abi(address=quaks_address_erc721)
abi, contract = chain.get_contract(address=quaks_address_erc721, abi=abi)
print(chain.get_token_standard(contract))

print("testing rarible. Should be ERC-1155")
abi = chain.get_contract_abi(address=rarible_address_erc1155)
abi, contract = chain.get_contract(address=rarible_address_erc1155, abi=abi)
print(chain.get_token_standard(contract))
```