### PR TITLE
Refactor ipfs.py to handle all valid IPFS URI and CID

### DIFF
--- a/honestnft_utils/chain.py
+++ b/honestnft_utils/chain.py
@@ -212,8 +212,7 @@ def get_token_uri_from_contract(contract, token_id, uri_func, abi):
 
     try:
         uri = uri_contract_func(token_id).call()
-        uri = ipfs.format_ipfs_uri(uri)
-        return uri
+        return format_metadata_uri(uri)
     except ContractLogicError as err:
         raise Exception(err)
 
@@ -247,7 +246,7 @@ def get_token_uri_from_contract_batch(
             call = Call(
                 target=contract.address,
                 function=[function_signature, token_id],
-                returns=[[token_id, ipfs.format_ipfs_uri]],
+                returns=[[token_id, format_metadata_uri]],
             )
             calls.append(call)
         multi = Multicall(calls, _w3=w3)
@@ -337,3 +336,18 @@ def get_token_standard(contract):
             if contract.functions.supportsInterface(identifier).call():
                 return standard
     return "Unknown standard"
+
+
+def format_metadata_uri(URI):
+    """
+    Given a metadata URI, return the formatted IPFS URI if it is an IPFS URI,
+    otherwise return the URI
+
+    :param URI: metadata URI
+    :type URI: str
+    :return: formatted URI
+    :rtype: str
+    """
+    if ipfs.is_valid_ipfs_uri(URI):
+        return ipfs.format_ipfs_uri(URI)
+    return URI

--- a/honestnft_utils/ipfs.py
+++ b/honestnft_utils/ipfs.py
@@ -3,6 +3,7 @@ import warnings
 from pathlib import Path
 
 import ipfshttpclient
+from is_ipfs import Validator
 
 from honestnft_utils import config
 
@@ -29,6 +30,17 @@ def get_file_suffix(filename, token_id="\\d+"):
         return ""
     else:
         raise ValueError("Provided token_id not found in filename")
+
+
+def is_valid_cid(cid):  # pragma: no cover
+    """
+    Given a CID, this function checks if it's a valid CID.
+
+    :param cid
+    :type cid: str
+    :rtype: bool
+    """
+    return Validator(cid)._is_cid()
 
 
 def infer_cid_from_uri(uri):

--- a/honestnft_utils/ipfs.py
+++ b/honestnft_utils/ipfs.py
@@ -68,9 +68,7 @@ def is_valid_ipfs_uri(uri):
     :type uri: str
     :rtype: bool
     """
-    if uri.find("ipfs") != -1 and infer_cid_from_uri(uri):
-        return True
-    return False
+    return Validator(uri).is_ipfs()
 
 
 def fetch_ipfs_folder(collection_name, cid, parent_folder, timeout=60):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pre-commit
 black
 black[jupyter]
 tox
+coverage

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,6 @@ setup(
         "multicall==0.2.0",
         "python-dotenv==0.19.2",
         "plotly==5.6.0",
+        "py-is_ipfs==0.4.0",
     ],
 )

--- a/tests/unit/test_ipfs.py
+++ b/tests/unit/test_ipfs.py
@@ -1,20 +1,74 @@
+from cmath import e
+from typing import Type
 import unittest
 import unittest.mock as mock
 
 from honestnft_utils import config
 from honestnft_utils import ipfs
 
-VALID_URIS = {
-    "/ipfs/QmUCseQWXCSrhf9edzVKTvoj8o8Ts5aXFGNPameZRPJ6uR": "QmUCseQWXCSrhf9edzVKTvoj8o8Ts5aXFGNPameZRPJ6uR",
-    "ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG": "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",
-    "ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/test.txt": "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",
-    "https://ipfs.io/ipfs/QmP5zQxwHXUYKNCfyXXeJ8K5YUUW5bGWiFRTguczmj491N/0.txt": "QmP5zQxwHXUYKNCfyXXeJ8K5YUUW5bGWiFRTguczmj491N",
-}
+VALID_URIS = [
+    {
+        "uri": "ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",
+        "cid": "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",
+        "suffix": "",
+    },
+    {
+        "uri": "/ipfs/bafybcfcqbwlhwbfq2k3ne2ysffcdoc4pmmsengy",
+        "cid": "bafybcfcqbwlhwbfq2k3ne2ysffcdoc4pmmsengy",
+        "suffix": "",
+    },
+    {
+        "uri": "ipfs://bafybeialdjathblysfa4ki6ryso7cmeiufeyvcwmeegmv53jxt3pyffzru/0.txt",
+        "cid": "bafybeialdjathblysfa4ki6ryso7cmeiufeyvcwmeegmv53jxt3pyffzru",
+        "suffix": "/0.txt",
+    },
+    {
+        "uri": "/ipfs/QmUCseQWXCSrhf9edzVKTvoj8o8Ts5aXFGNPameZRPJ6uR",
+        "cid": "QmUCseQWXCSrhf9edzVKTvoj8o8Ts5aXFGNPameZRPJ6uR",
+        "suffix": "",
+    },
+    {
+        "uri": "https://ipfs.io/ipfs/QmP5zQxwHXUYKNCfyXXeJ8K5YUUW5bGWiFRTguczmj491N/0.txt",
+        "cid": "QmP5zQxwHXUYKNCfyXXeJ8K5YUUW5bGWiFRTguczmj491N",
+        "suffix": "/0.txt",
+    },
+    {
+        "uri": "https://bafybeialdjathblysfa4ki6ryso7cmeiufeyvcwmeegmv53jxt3pyffzru.ipfs.dweb.link/0.txt?loc=123",
+        "cid": "bafybeialdjathblysfa4ki6ryso7cmeiufeyvcwmeegmv53jxt3pyffzru",
+        "suffix": "/0.txt?loc=123",
+    },
+    {
+        "uri": "ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",
+        "cid": "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",
+        "suffix": "",
+    },
+    {
+        "uri": "ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/test.txt",
+        "cid": "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",
+        "suffix": "/test.txt",
+    },
+    {
+        "uri": "https://ipfs.io/ipfs/bafybeialdjathblysfa4ki6ryso7cmeiufeyvcwmeegmv53jxt3pyffzru/0.txt",
+        "cid": "bafybeialdjathblysfa4ki6ryso7cmeiufeyvcwmeegmv53jxt3pyffzru",
+        "suffix": "/0.txt",
+    },
+    {
+        "uri": "https://hungrywolves.mypinata.cloud/ipfs/QmU9miGYP6wGPodb3AE7LbAyKSF9bxq9CbeKmF5U7DfCt1/4000",
+        "cid": "QmU9miGYP6wGPodb3AE7LbAyKSF9bxq9CbeKmF5U7DfCt1",
+        "suffix": "/4000",
+    },
+]
 
-INVALID_URIS = {
-    "ipfs://1264/test.txt": None,
-    "https://ipfs.io/ipfsqmUCseQWXCSrhf9edzVKTvoj8o8Ts5aXFGNPameZRPJ6u/test.txt": None,
-}
+INVALID_URIS = [
+    "https://ipfs.io/ipfs/QmYwAPJzv5CZsnA6s3Xf2nemtYgPpHdWEz79ojWnPbdG/test.txt",
+    "ipfs://1264/test.txt",
+    "https://ipfs.io/ipfsqmUCseQWXCSrhf9edzVKTvoj8o8Ts5aXFGNPameZRPJ6u/test.txt",
+    "https://ipfs.io/ipfs/124/test.txt",
+    "/IPFS/QmNOTAVALIDCID",
+    1234,
+    None,
+    b"19",
+]
 
 
 class TestCase(unittest.TestCase):
@@ -31,51 +85,36 @@ class TestCase(unittest.TestCase):
         )
 
     def test_format_ipfs_uri(self):
-        self.assertEqual(
-            ipfs.format_ipfs_uri(
-                "ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG"
-            ),
-            f"{config.IPFS_GATEWAY}QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",
-        )
-        self.assertEqual(
-            ipfs.format_ipfs_uri(
-                "ipfs://bafybeialdjathblysfa4ki6ryso7cmeiufeyvcwmeegmv53jxt3pyffzru"
-            ),
-            f"{config.IPFS_GATEWAY}bafybeialdjathblysfa4ki6ryso7cmeiufeyvcwmeegmv53jxt3pyffzru",
-        )
-        self.assertEqual(
-            ipfs.format_ipfs_uri(
-                "https://gateway.pinata.cloud/ipfs/bafybeialdjathblysfa4ki6ryso7cmeiufeyvcwmeegmv53jxt3pyffzru"
-            ),
-            f"{config.IPFS_GATEWAY}bafybeialdjathblysfa4ki6ryso7cmeiufeyvcwmeegmv53jxt3pyffzru",
-        )
-        self.assertEqual(
-            ipfs.format_ipfs_uri(
-                "https://hungrywolves.mypinata.cloud/ipfs/QmU9miGYP6wGPodb3AE7LbAyKSF9bxq9CbeKmF5U7DfCt1/4000"
-            ),
-            f"{config.IPFS_GATEWAY}QmU9miGYP6wGPodb3AE7LbAyKSF9bxq9CbeKmF5U7DfCt1/4000",
-        )
+        with self.subTest("Testing valid URIs"):
+            for entry in VALID_URIS:
+                self.assertEqual(
+                    ipfs.format_ipfs_uri(entry["uri"]),
+                    f"{config.IPFS_GATEWAY}{entry['cid']}{entry['suffix']}",
+                )
 
-        self.assertEqual(
-            ipfs.format_ipfs_uri(
-                "https://ipfs.io/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG"
-            ),
-            f"{config.IPFS_GATEWAY}QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",
-        )
+        with self.subTest("Testing invalid URIs"):
+            for entry in INVALID_URIS:
+                if type(entry) == str:
+                    self.assertRaises(ValueError, ipfs.format_ipfs_uri, entry)
+            else:
+                self.assertRaises(TypeError, ipfs.format_ipfs_uri, entry)
 
     def test_infer_cid_from_uri(self):
-        for uri, cid in VALID_URIS.items():
-            self.assertEqual(ipfs.infer_cid_from_uri(uri), cid)
-            self.assertIs(type(ipfs.infer_cid_from_uri(uri)), str)
+        for entry in VALID_URIS:
+            self.assertEqual(ipfs.infer_cid_from_uri(entry["uri"]), entry["cid"])
+            self.assertIs(type(ipfs.infer_cid_from_uri(entry["uri"])), str)
 
-        for uri, cid in INVALID_URIS.items():
-            self.assertEqual(ipfs.infer_cid_from_uri(uri), cid)
+        for entry in INVALID_URIS:
+            if type(entry) == str:
+                self.assertIsNone(ipfs.infer_cid_from_uri(entry))
+            else:
+                self.assertRaises(TypeError, ipfs.infer_cid_from_uri, entry)
 
     def test_is_valid_ipfs_uri(self):
-        for uri, cid in VALID_URIS.items():
-            self.assertTrue(ipfs.is_valid_ipfs_uri(uri))
-        for uri, cid in INVALID_URIS.items():
-            self.assertFalse(ipfs.is_valid_ipfs_uri(uri))
+        for entry in VALID_URIS:
+            self.assertTrue(ipfs.is_valid_ipfs_uri(entry["uri"]))
+        for entry in INVALID_URIS:
+            self.assertFalse(ipfs.is_valid_ipfs_uri(entry))
 
     @mock.patch("honestnft_utils.config.IPFS_GATEWAY", "")
     def test_mock_with_empty_gateway(self):


### PR DESCRIPTION
The current implementation limited us to only handle specific URI formats and only CIDv0.

With this PR we should be able to handle all URI formats and all CID versions/encodings. 