### PR TITLE
feat: Better file extension detection for pulling.py

### DIFF
--- a/honestnft_utils/ipfs.py
+++ b/honestnft_utils/ipfs.py
@@ -126,10 +126,9 @@ def fetch_ipfs_folder(
                     "Failed to download metadata folder from IPFS. Trying next gateway..."
                 )
             else:
-                print("Failed to download metadata folder from IPFS.")
                 if Path.exists(cid_path):
                     cid_path.rename(collection_path)
-            pass
+                raise Exception("Failed to download metadata folder from IPFS.")
 
 
 def format_ipfs_uri(uri: str) -> str:

--- a/honestnft_utils/misc.py
+++ b/honestnft_utils/misc.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -41,3 +43,16 @@ def mount_session() -> requests.Session:
     session.mount(prefix="http://", adapter=adapter)
 
     return session
+
+
+def get_first_filename_in_dir(dir_path: Path) -> str:
+    """Get the first filename in a directory
+
+    :param dir_path: The path to the directory
+    :raises FileNotFoundError: if the directory is empty
+    :return: The name of the first file in the directory
+    """
+    for file_path in dir_path.iterdir():
+        if file_path.is_file():
+            return file_path.name
+    raise FileNotFoundError("No files found in directory")

--- a/metadata/pulling.py
+++ b/metadata/pulling.py
@@ -462,13 +462,6 @@ def _cli_parser() -> argparse.ArgumentParser:
 if __name__ == "__main__":
 
     """
-    There are some cases we have found that are not covered by this script:
-    https://etherscan.io/token/0xff9c1b15b16263c61d017ee9f65c50e4ae0113d7
-    https://etherscan.io/address/0x743f80dc76f862a27598140196cc610006b2be68
-    https://etherscan.io/address/0x8197c9d748287dc1ce7b35ad8dfff4a79a54a1c4
-    """
-
-    """
     Retrieve NFT metadata from remote server. A couple configurations are available.
 
     1) Provide a contract address and infer all underlying parameters

--- a/metadata/pulling.py
+++ b/metadata/pulling.py
@@ -461,23 +461,6 @@ def _cli_parser() -> argparse.ArgumentParser:
 
 if __name__ == "__main__":
 
-    """
-    Retrieve NFT metadata from remote server. A couple configurations are available.
-
-    1) Provide a contract address and infer all underlying parameters
-    python3 pulling.py -contract 0x09eqhc0iqy80eychq8hn8dhqwc
-
-    2) Provide a URI base, collection name, lower_id, and max_supply
-    python3 pulling.py -uri_base https://punks.com/api/ -collection punks -lower_id 0 -max_supply 10000
-
-    When retrieving metadata by inferring the URI directly from the contract function,  we assume:
-    1) Contract ABI is posted publicly on etherscan.
-    2) Contract address points to either an NFT contract or an associated proxy contract that
-       has an NFT contract as an implementation contract. Note that get_contract is called
-       recursively if the provided contract address yields and ABI that contains a function
-       called 'implementation'
-    """
-
     # Parse command line arguments
 
     ARGS = _cli_parser().parse_args()

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+from pathlib import Path
+
+from honestnft_utils import misc
+from tests import helpers
+
+
+class TestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_path = Path(f"{helpers.TESTS_ROOT_DIR}/temp")
+        self.temp_path.mkdir(parents=True, exist_ok=True)
+
+    def test_get_first_filename_in_dir(self):
+        with open(f"{self.temp_path}/testfile1.txt", "w") as f:
+            f.write("GM World")
+        with open(f"{self.temp_path}/testfile2.txt", "w") as f:
+            f.write("GM World")
+
+        folder_walk = os.walk(
+            self.temp_path, topdown=True, onerror=None, followlinks=False
+        )
+        _files = next(folder_walk)[2]
+        first_file = _files[0]
+        self.assertEqual(misc.get_first_filename_in_dir(self.temp_path), first_file)
+
+    def test_get_first_filename_in_dir_no_file(self):
+        self.assertRaises(
+            FileNotFoundError,
+            misc.get_first_filename_in_dir,
+            self.temp_path,
+        )
+
+    def tearDown(self) -> None:
+        Path(self.temp_path, "testfile1.txt").unlink(missing_ok=True)
+        Path(self.temp_path, "testfile2.txt").unlink(missing_ok=True)
+        self.temp_path.rmdir()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
If the ipfs folder download failed, we did not check for the file_extension and simply used ".json", which is often incorrect.
This PR implements a new function (which is also faster than the previous method)  to check the first file of the folder, before passing it to the existing function get_file_suffix.

Thanks to @dlrec for flagging this issue.
