### PR TITLE
feat: detect dedicated Pinata gateway, allow skipping ipfs folder download

### DIFF
--- a/honestnft_utils/chain.py
+++ b/honestnft_utils/chain.py
@@ -254,15 +254,21 @@ def get_contract_function(contract: Contract, func_name: str, abi: list):
 
 
 def get_token_uri_from_contract(
-    contract: Contract, token_id: int, uri_func: str, abi: list
+    contract: Contract,
+    token_id: int,
+    uri_func: str,
+    abi: list,
+    format_uri: bool = False,
 ) -> str:
     """
     Given a contract, token ID, and URI function name, return the token URI.
+    Optionally, format the URI.
 
     :param contract: The contract object
     :param token_id: The token ID
     :param uri_func: The URI function name
     :param abi: The contract ABI
+    :param format_uri: Whether to format the URI
     :return: The token URI
     """
     # Fetch URI from contract
@@ -270,7 +276,10 @@ def get_token_uri_from_contract(
 
     try:
         uri = uri_contract_func(token_id).call()
-        return format_metadata_uri(uri)
+        if format_uri:
+            return format_metadata_uri(uri)
+        else:
+            return uri
     except ContractLogicError as err:
         raise Exception(err)
 
@@ -281,9 +290,11 @@ def get_token_uri_from_contract_batch(
     function_signature: str,
     abi: list,
     blockchain: str = "ethereum",
+    format_uri: bool = False,
 ) -> Dict[int, str]:
     """
     Given a contract, token IDs, and function signature, return the token URIs.
+    Optionally, format the URI.
 
     :param contract: The contract object
     :param token_ids: A list of token IDs
@@ -297,7 +308,7 @@ def get_token_uri_from_contract_batch(
         - fantom
         - optimism
         - polygon
-
+    :param format_uri: Whether to format the URI
     :return: A dictionary of token IDs and URIs
     """
     if blockchain == "arbitrum":
@@ -328,7 +339,7 @@ def get_token_uri_from_contract_batch(
             call = Call(
                 target=contract.address,
                 function=[function_signature, token_id],
-                returns=[[token_id, format_metadata_uri]],
+                returns=[[token_id, format_metadata_uri if format_uri else str]],
             )
             calls.append(call)
         multi = Multicall(calls, _w3=w3)

--- a/honestnft_utils/chain.py
+++ b/honestnft_utils/chain.py
@@ -279,7 +279,7 @@ def get_token_uri_from_contract(
         if format_uri:
             return format_metadata_uri(uri)
         else:
-            return uri
+            return str(uri)
     except ContractLogicError as err:
         raise Exception(err)
 

--- a/honestnft_utils/ipfs.py
+++ b/honestnft_utils/ipfs.py
@@ -162,3 +162,18 @@ def format_ipfs_uri(uri: str) -> str:
                 scheme="https", netloc=urlparse(gateway).netloc
             ).geturl()
     raise ValueError("No CID found in URI")
+
+
+def is_dedicated_pinata_gateway(url: str) -> bool:
+    """
+    Given a gateway, this function checks if it's a custom Pinata gateway.
+    """
+    pattern = r"^((?!-)[a-z0-9-]{0,63}[a-z0-9])\.mypinata\.cloud"
+
+    # if "mypinata.cloud" in url:
+    parse_result = urlparse(str(url))
+
+    if re.match(pattern, parse_result.netloc) or re.match(pattern, parse_result.path):
+        return True
+
+    return False

--- a/honestnft_utils/ipfs.py
+++ b/honestnft_utils/ipfs.py
@@ -103,13 +103,12 @@ def fetch_ipfs_folder(
 
     infura = "/dns/infura-ipfs.io/tcp/5001/https"
     ipfs_io = "/dns/ipfs.io/tcp/443/https"
-    ipfs_gateway_io = "/dns/gateway.ipfs.io/tcp/443/https"
     dweb_link = "/dns/dweb.link/tcp/443/https"
     pinata = "/dns/gateway.pinata.cloud/tcp/443/https"
     warnings.filterwarnings(
         "ignore", category=ipfshttpclient.exceptions.VersionMismatch
     )
-    gateways = [pinata, ipfs_gateway_io, infura, dweb_link, ipfs_io]
+    gateways = [ipfs_io, infura, dweb_link, pinata]
     print("Attempting to download metadata folder from IPFS...\nPlease wait...")
 
     for gateway in range(len(gateways)):

--- a/metadata/pulling.py
+++ b/metadata/pulling.py
@@ -60,6 +60,7 @@ def fetch_all_metadata(
     uri_suffix: str,
     blockchain: str,
     threads: int,
+    skip_ipfs_folder: bool,
 ) -> list:
 
     # Create raw attribute folder for collection if it doesnt already exist
@@ -87,7 +88,11 @@ def fetch_all_metadata(
             uri_base = config.IPFS_GATEWAY + cid + "/"
 
     # First try to get all metadata files from ipfs in bulk
-    if uri_base is not None and ipfs.is_valid_ipfs_uri(uri_base):
+    if (
+        skip_ipfs_folder == False
+        and uri_base is not None
+        and ipfs.is_valid_ipfs_uri(uri_base)
+    ):
 
         if len(list(Path(folder).iterdir())) == 0:
             cid = ipfs.infer_cid_from_uri(uri_base)
@@ -101,6 +106,7 @@ def fetch_all_metadata(
                 bulk_ipfs_success = True
             except Exception:
                 print("Falling back to individual file downloads...")
+
     try:
         first_filename = misc.get_first_filename_in_dir(Path(folder))
         file_suffix = ipfs.get_file_suffix(first_filename)
@@ -334,6 +340,7 @@ def pull_metadata(args: argparse.Namespace) -> None:
         uri_suffix=args.uri_suffix,
         blockchain=args.blockchain,
         threads=args.threads,
+        skip_ipfs_folder=args.skip_ipfs_folder,
     )
 
     # Generate traits DataFrame and save to disk as csv
@@ -444,6 +451,11 @@ def _cli_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help=f"Number of threads to use for downloading metadata. (default: {min(32, os.cpu_count() + 4)})",  # type: ignore
+    )
+    parser.add_argument(
+        "--skip_ipfs_folder",
+        action="store_true",
+        help="Skip IPFS folder download.",
     )
 
     return parser

--- a/tests/unit/test_ipfs.py
+++ b/tests/unit/test_ipfs.py
@@ -136,6 +136,8 @@ class TestCase(unittest.TestCase):
             "",
             None,
             218983,
+            "ipfs://QmUCseQWXCSrhf9edzVKTvoj8o8Ts5aXFGNPameZRPJ6uR",
+            "/ipfs/QmUCseQWXCSrhf9edzVKTvoj8o8Ts5aXFGNPameZRPJ6uR",
         ]
 
         for entry in valid_pinata_gateways:

--- a/tests/unit/test_ipfs.py
+++ b/tests/unit/test_ipfs.py
@@ -1,8 +1,7 @@
 import unittest
 import unittest.mock as mock
 
-from honestnft_utils import config
-from honestnft_utils import ipfs
+from honestnft_utils import config, ipfs
 
 VALID_URIS = [
     {
@@ -122,6 +121,28 @@ class TestCase(unittest.TestCase):
             ),
             "https://ipfs.io/ipfs/QmUCseQWXCSrhf9edzVKTvoj8o8Ts5aXFGNPameZRPJ6uR",
         )
+
+    def test_is_dedicated_pinata_gateway(self):
+        valid_pinata_gateways = [
+            "https://hungrywolves.mypinata.cloud/ipfs/QmLoremIpsum",
+            "http://a-valid-gateway.mypinata.cloud/ipfs/QmLoremIpsum",
+            "also-valid.mypinata.cloud",
+        ]
+        invalid_pinata_gateways = [
+            "www.not-valid.mypinata.cloud",
+            "https://not-valid.mypinata.com",
+            "https://ipfs.io",
+            "https://ipfs.io/ipfs/QmUCseQWXCSrhf9edzVKTvoj8o8Ts5aXFGNPameZRPJ6uR",
+            "",
+            None,
+            218983,
+        ]
+
+        for entry in valid_pinata_gateways:
+            self.assertTrue(ipfs.is_dedicated_pinata_gateway(entry), entry)
+
+        for entry in invalid_pinata_gateways:
+            self.assertFalse(ipfs.is_dedicated_pinata_gateway(entry), entry)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR introduces a few changes that should noticeably increase the download speed when a project has a [dedicated Pinata gateway](https://docs.pinata.cloud/gateways/dedicated-gateways). A dedicated gateway is always faster than downloading from a public gateway.

For example [Azuki](https://etherscan.io/address/0xed5af388653567af2f388e6224dc7c4b3241c544) uses `https://ikzttp.mypinata.cloud/ipfs/Qm.........`. In this case it makes sense to skip the ipfs folder download AND use their dedicated gateway instead of our config.IPFS_GATEWAY

--------

You can also skip the ipfs folder download manually by using the argument `--skip_ipfs_folder`