### PR TITLE
fix: extract autoprogram title

### DIFF
--- a/docs/source/fair_drop.suspicious.rst
+++ b/docs/source/fair_drop.suspicious.rst
@@ -8,10 +8,13 @@ Scraped data is stored in `data/suspicious_nfts/`.
    * We currently only support collections with incrementing IDs
    * Only Ethereum NFTs can be scraped
 
+
+Command Line
+------------
 .. autoprogram:: fair_drop.suspicious:_cli_parser()
    :prog: suspicious.py
    :no_description:
-   :custom_title: Command Line
+   :no_title: 
 
 ------------
 

--- a/docs/source/metadata.pull_from_objkt.rst
+++ b/docs/source/metadata.pull_from_objkt.rst
@@ -10,10 +10,12 @@ Here is how to download Tezzardz metadata from the terminal:
    $ python3 metadata/pull_from_objkt.py -contract KT1LHHLso8zQWQWg1HUukajdxxbkGfNoHjh6
 
 
+Command Line
+------------
 .. autoprogram:: metadata.pull_from_objkt:_cli_parser()
    :prog: pull_from_objkt.py
    :no_description:
-   :custom_title: Command Line
+   :no_title:
 
 ------------
 

--- a/docs/source/metadata.pull_from_raritysniffer.rst
+++ b/docs/source/metadata.pull_from_raritysniffer.rst
@@ -10,10 +10,12 @@ This module can be used to download NFT metadata and rarity data from RaritySnif
    $ python3 metadata/pull_from_raritysniffer.py --contract 0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d
 
 
+Command Line
+------------
 .. autoprogram:: metadata.pull_from_raritysniffer:_cli_parser()
    :prog: pull_from_rt.py
    :no_description:
-   :custom_title: Command Line
+   :no_title:
 
 ------------
 

--- a/docs/source/metadata.pull_from_rt.rst
+++ b/docs/source/metadata.pull_from_rt.rst
@@ -11,10 +11,12 @@ Whereas most of our modules rely on the contract address, this one relies on the
    $ python3 metadata/pull_from_rt.py --collection cryptopunks
 
 
+Command Line
+------------
 .. autoprogram:: metadata.pull_from_rt:_cli_parser()
    :prog: pull_from_rt.py
    :no_description:
-   :custom_title: Command Line
+   :no_title:
 
 ------------
 

--- a/docs/source/metadata.pull_from_solana.rst
+++ b/docs/source/metadata.pull_from_solana.rst
@@ -10,11 +10,12 @@ You will need an API key from :ref:`guides/api-keys:the index` to use this modul
    $ python3 metadata/pull_from_solana.py --contract DSwfRF1jhhu6HpSuzaig1G19kzP73PfLZBPLofkw6fLD --collection solana_degenerate_ape_academy
 
 
-
+Command Line
+------------
 .. autoprogram:: metadata.pull_from_solana:_cli_parser()
    :prog: pull_from_solana.py
    :no_description:
-   :custom_title: Command Line
+   :no_title:
 
 ------------
 

--- a/docs/source/metadata.pulling.rst
+++ b/docs/source/metadata.pulling.rst
@@ -1,10 +1,12 @@
 metadata.pulling
 ================
 
+Command Line
+------------
 .. autoprogram:: metadata.pulling:_cli_parser()
    :prog: pulling.py
    :no_description:
-   :custom_title: Command Line
+   :no_title:
 
 ------------
 

--- a/docs/source/metadata.rarity.rst
+++ b/docs/source/metadata.rarity.rst
@@ -2,10 +2,12 @@
 metadata.rarity
 ===============
 
+Command Line
+------------
 .. autoprogram:: metadata.rarity:_cli_parser()
    :prog: rarity.py
    :no_description:
-   :custom_title: Command Line
+   :no_title:
 
 ------------
 


### PR DESCRIPTION
This PR fixes a lay-out issue where the CLI section was indented if the previous section had a title.